### PR TITLE
chore: Make CI faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-
-      # Needed to make godot-tester not fail. It is unclear why this works.
-    - run: touch test_results.xml
-
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        path: './'
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: croconut/godot-tester@v5
+    - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required
         version: "4.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        path: './'
+        fetch-depth: 0
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      # TODO: Use croconut/godot-tester after https://github.com/croconut/godot-tester/pull/40 is merged
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         # the folder with your project.godot file in it
         path: "./"
         # how long to spend importing assets before tests are run
-        import-time: "5"
+        import-time: ""
         # how long tests can run in seconds
-        test-timeout: "45"
+        test-timeout: ""
         # the ratio of tests that must pass for this action to pass
         # e.g. 0.6 means 60% of your tests must pass
         minimum-pass: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
+      # Needed to make godot-tester not fail. It is unclear why this works.
+    - run: touch test_results.xml
+
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
         is-mono: "false"
         # the folder with your project.godot file in it
         path: "./"
-        # how long to spend importing assets before tests are run
-        import-time: ""
-        # how long tests can run in seconds
-        test-timeout: ""
         # the ratio of tests that must pass for this action to pass
         # e.g. 0.6 means 60% of your tests must pass
         minimum-pass: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v2
     - uses: rainbowcow-studio/godot-tester@feature/node-20
       with:
         # required


### PR DESCRIPTION
This PR avoids [a needless 60 second wait](https://github.com/rainbowcow-studio/farmhand-shuffle/actions/runs/6327316140/job/17182862771#step:2:544) in CI jobs by using https://github.com/croconut/godot-tester/pull/40. It also improves CI reliability by removing `import-time` and `test-timeout` options per [the workaround described in this comment](https://github.com/croconut/godot-tester/issues/36#issuecomment-1663196875).